### PR TITLE
[Feat] 초기데이터 api 연동

### DIFF
--- a/Peakly-FE/src/App.js
+++ b/Peakly-FE/src/App.js
@@ -4,6 +4,8 @@ import { AuthProvider } from './contexts/AuthContext';
 import { StatusBar } from 'expo-status-bar';
 import { View } from 'react-native';
 import CustomTag from './screens/onBoardingScreens/CustomTag';
+import { NavigationContainer } from '@react-navigation/native';
+import OnboardingStack from './navigations/OnboardingStack';
 
 function App() {
   const [fontsLoaded] = useFonts({
@@ -15,14 +17,10 @@ function App() {
   if (!fontsLoaded) return null;
 
   return (
-    /* 
     <AuthProvider>
       <StatusBar style="auto" />
       <AppNavigator />
-    </AuthProvider> */
-    <View style={{ flex: 1 }}>
-      <CustomTag />
-    </View>
+    </AuthProvider>
   );
 }
 

--- a/Peakly-FE/src/api/auth.js
+++ b/Peakly-FE/src/api/auth.js
@@ -39,6 +39,8 @@ export const sendVerifyEmail = async (email) => {
 
 // 이메일 인증 토큰 검증 (email-verify)
 export const verifyEmail = async (token) => {
-  const response = await client.post('auth/email-verify', { token });
+  const response = await client.get('auth/email-verify', {
+    params: { token },
+  });
   return response.data;
 };

--- a/Peakly-FE/src/api/users.js
+++ b/Peakly-FE/src/api/users.js
@@ -1,0 +1,15 @@
+import client from './client';
+
+// 초기 데이터 수집 (initial-data)
+
+export const postInitialData = async (data) => {
+  try {
+    const response = await client.post('users/initial-data', data);
+    return response.data;
+  } catch (error) {
+    if (error.response && error.response.status === 409) {
+      console.warn('이미 초기 데이터가 등록된 사용자입니다.');
+    }
+    throw error;
+  }
+};

--- a/Peakly-FE/src/contexts/AuthContext.js
+++ b/Peakly-FE/src/contexts/AuthContext.js
@@ -6,6 +6,9 @@ import {
   getRefreshToken,
   setRefreshToken,
   removeRefreshToken,
+  getInitialData,
+  setInitialData,
+  removeInitialData,
 } from '../utils/storage';
 
 const AuthContext = createContext();
@@ -13,17 +16,15 @@ const AuthContext = createContext();
 export const AuthProvider = ({ children }) => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [hasCompleteOnboarding, setHasCompleteOnboarding] = useState(false);
 
   useEffect(() => {
     const initAuth = async () => {
       try {
-        const token = await getToken();
+        const [token, initialData] = await Promise.all([getToken(), getInitialData()]);
 
-        if (token) {
-          setIsLoggedIn(true);
-        } else {
-          setIsLoggedIn(false);
-        }
+        setIsLoggedIn(!!token);
+        setHasCompleteOnboarding(!!initialData);
       } catch (e) {
         console.error('인증 초기화 실패: ', e);
         setIsLoggedIn(false);
@@ -39,22 +40,34 @@ export const AuthProvider = ({ children }) => {
     if (refresh_token) {
       await setRefreshToken(refresh_token);
     }
+
+    const onboardingDone = await getInitialData();
+    setHasCompleteOnboarding(onboardingDone);
     setIsLoggedIn(true);
   };
 
   const logout = async () => {
-    await Promise.all([removeToken(), removeRefreshToken()]);
+    await Promise.all([removeToken(), removeRefreshToken(), removeInitialData()]);
     setIsLoggedIn(false);
+    setHasCompleteOnboarding(false);
+  };
+
+  const completeOnboarding = async (data) => {
+    const dataToSave = data || true;
+    await setInitialData(dataToSave);
+    setHasCompleteOnboarding(true);
   };
 
   const contextValue = useMemo(
     () => ({
       isLoggedIn,
       isLoading,
+      hasCompleteOnboarding,
       login,
       logout,
+      completeOnboarding,
     }),
-    [isLoggedIn, isLoading],
+    [isLoggedIn, isLoading, hasCompleteOnboarding],
   );
 
   return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;

--- a/Peakly-FE/src/navigations/AppNavigator.jsx
+++ b/Peakly-FE/src/navigations/AppNavigator.jsx
@@ -3,18 +3,23 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import MainStack from './MainStack';
 import AuthStack from './AuthStack';
+import OnboardingStack from './OnboardingStack';
 import EmptyScreen from '../screens/onBoardingScreens/EmptyScreen';
 
 import { useAuth } from '../contexts/AuthContext';
 
 const AppNavigator = () => {
-  const { isLoggedIn, isLoading } = useAuth();
+  const { isLoggedIn, isLoading, hasCompleteOnboarding } = useAuth();
 
   if (isLoading) {
     return <EmptyScreen />;
   }
 
-  return <NavigationContainer>{!isLoggedIn ? <AuthStack /> : <MainStack />}</NavigationContainer>;
+  return (
+    <NavigationContainer>
+      {isLoggedIn ? hasCompleteOnboarding ? <MainStack /> : <OnboardingStack /> : <AuthStack />}
+    </NavigationContainer>
+  );
 };
 
 export default AppNavigator;

--- a/Peakly-FE/src/screens/onBoardingScreens/Caffeine.jsx
+++ b/Peakly-FE/src/screens/onBoardingScreens/Caffeine.jsx
@@ -6,18 +6,33 @@ import ConditionSlider from '../../components/ConditionSlider';
 import CustomButton from '../../components/CustomButton';
 import Header from './components/Header';
 
-const Caffeine = () => {
+const Caffeine = ({ navigation, route }) => {
   const [caffeine, setCaffeine] = useState(50);
+  const { accumulatedData } = route.params || {};
 
   const getCaffeineText = (val) => {
-    if (val <= 0) return '반응이 없는 편이에요.';
+    if (val <= 0) return '상관없어요.';
     if (val <= 50) return '보통이에요.';
     return '매우 민감해요.';
   };
 
+  const handleNext = () => {
+    let apiValue = 1;
+
+    if (caffeine === 0) apiValue = 0;
+    else if (caffeine === 50) apiValue = 1;
+    else if (caffeine >= 100) apiValue = 2;
+    navigation.navigate('Noise', {
+      accumulatedData: {
+        ...accumulatedData,
+        caffeineResponsiveness: apiValue,
+      },
+    });
+  };
+
   return (
     <View style={styles.container}>
-      <Header totalStep={7} currentStep={3} />
+      <Header totalStep={7} currentStep={3} onPress={() => navigation.goBack()} />
       <View style={styles.titleContainer}>
         <Text style={styles.title}>카페인 반응도는{'\n'}어떤편인가요?</Text>
         <Text style={[styles.title, styles.subtitle]}>언제 가장 집중이 잘 되나요?</Text>
@@ -32,7 +47,7 @@ const Caffeine = () => {
           dotCount={3}
         />
       </View>
-      <CustomButton style={styles.button} text={'다음'} />
+      <CustomButton style={styles.button} text={'다음'} onPress={handleNext} />
     </View>
   );
 };

--- a/Peakly-FE/src/screens/onBoardingScreens/ChronoType.jsx
+++ b/Peakly-FE/src/screens/onBoardingScreens/ChronoType.jsx
@@ -1,4 +1,4 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, Alert } from 'react-native';
 import React, { useState } from 'react';
 import Header from './components/Header';
 import { colors } from '../../styles/colors';
@@ -6,16 +6,33 @@ import OnBording from '../../../assets/img/Onboarding/onboarding1.svg';
 import Button from './components/Button';
 import CustomButton from '../../components/CustomButton';
 
-const ChronoType = () => {
+const ChronoType = ({ navigation }) => {
   const [selected, setSelected] = useState('');
 
   const handlePress = (type) => {
     setSelected(type);
   };
 
+  const handleNext = () => {
+    if (!selected) {
+      Alert.alert('알림', '유형을 선택해주세요.');
+      return;
+    }
+    let apiValue = '';
+    if (selected === '아침형') apiValue = 'MORNING';
+    else if (selected === '중간형') apiValue = 'AFTERNOON';
+    else if (selected === '저녁형') apiValue = 'NIGHT';
+
+    navigation.navigate('PeakTime', {
+      accumulatedData: {
+        chronotype: apiValue,
+      },
+    });
+  };
+
   return (
     <View style={styles.container}>
-      <Header totalStep={7} currentStep={1} />
+      <Header totalStep={7} currentStep={1} onPress={() => navigation.goBack()} />
       <View style={styles.titleContainer}>
         <Text style={styles.title}>크로노타입</Text>
         <Text style={[styles.title, styles.subtitle]}>
@@ -40,7 +57,7 @@ const ChronoType = () => {
           onPress={() => handlePress('저녁형')}
         />
       </View>
-      <CustomButton style={styles.button} text={'다음'} />
+      <CustomButton style={styles.button} text={'다음'} onPress={handleNext} />
     </View>
   );
 };

--- a/Peakly-FE/src/screens/onBoardingScreens/CompleteScreen.jsx
+++ b/Peakly-FE/src/screens/onBoardingScreens/CompleteScreen.jsx
@@ -1,10 +1,41 @@
-import { StyleSheet, Text, View, Platform } from 'react-native';
+import { useState } from 'react';
+import { StyleSheet, Text, View, Alert } from 'react-native';
 import Complete from '../../../assets/img/Onboarding/complete.svg';
 import { colors } from '../../styles/colors';
 import CustomButton from '../../components/CustomButton';
 import Header from './components/Header';
 
-const CompleteScreen = () => {
+// api
+import { postInitialData } from '../../api/users';
+import { useAuth } from '../../contexts/AuthContext';
+
+const CompleteScreen = ({ route }) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const { completeOnboarding, logout } = useAuth();
+  const { accumulatedData } = route.params || {};
+
+  const handleComplete = async () => {
+    if (isLoading) return;
+
+    console.log('📦 [DEBUG] 온보딩 최종 전송 데이터 (accumulatedData):');
+    console.log(JSON.stringify(accumulatedData, null, 2));
+
+    try {
+      setIsLoading(true);
+      await postInitialData(accumulatedData);
+      await completeOnboarding(accumulatedData);
+    } catch (error) {
+      if (error.response?.status === 409) {
+        await completeOnboarding(accumulatedData);
+      } else {
+        console.error('온보딩 최종 저장 실패:', error);
+        Alert.alert('알림', '데이터 저장 중 오류가 발생했습니다. 다시 시도해 주세요.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
     <View style={styles.container}>
       <Header totalStep={7} currentStep={7} />
@@ -13,11 +44,10 @@ const CompleteScreen = () => {
         <Text style={styles.subTitle}>선턱하신 설정은 나중에 변경할 수 있어요.</Text>
       </View>
       <Complete />
-      <CustomButton style={styles.button} text={'완료'} />
+      <CustomButton style={styles.button} text={'완료'} onPress={handleComplete} />
     </View>
   );
 };
-
 export default CompleteScreen;
 
 const styles = StyleSheet.create({

--- a/Peakly-FE/src/screens/onBoardingScreens/CustomTag.jsx
+++ b/Peakly-FE/src/screens/onBoardingScreens/CustomTag.jsx
@@ -7,16 +7,17 @@ import CategoryCreate from '../../components/CategoryCreate';
 import { categoryApi } from '../../api/category';
 
 const CATEGORY_MAP = {
-  '암기': 1,
-  '이해': 2,
+  암기: 1,
+  이해: 2,
   '논리·사고': 3,
-  '반복': 4,
+  반복: 4,
   '창의·구상': 5,
 };
 
-const CustomTag = () => {
-  const [tags, setTags] = useState([]); 
+const CustomTag = ({ navigation, route }) => {
+  const [tags, setTags] = useState([]);
   const [selectedCategoryName, setSelectedCategoryName] = useState('암기');
+  const { accumulatedData } = route.params || {};
 
   const fetchTags = useCallback(async (majorId) => {
     try {
@@ -34,7 +35,7 @@ const CustomTag = () => {
   const handleCategoryChange = (categoryName) => {
     setSelectedCategoryName(categoryName);
     const majorId = CATEGORY_MAP[categoryName];
-    fetchTags(majorId); 
+    fetchTags(majorId);
   };
 
   const handleAddTag = async (tagName, selectedCategory) => {
@@ -43,7 +44,7 @@ const CustomTag = () => {
 
     try {
       await categoryApi.createCustomTag(tagName, majorId);
-      await fetchTags(majorId); 
+      await fetchTags(majorId);
     } catch (error) {
       Alert.alert('알림', '태그 생성 실패');
     }
@@ -58,24 +59,36 @@ const CustomTag = () => {
     }
   };
 
+  const handleNext = async () => {
+    navigation.navigate('CompleteScreen', {
+      accumulatedData: accumulatedData,
+    });
+  };
+
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
       <View style={styles.container}>
-        <Header totalStep={7} currentStep={6} />
+        <Header
+          totalStep={7}
+          currentStep={6}
+          onPress={() => {
+            navigation.goBack();
+          }}
+        />
 
         <View style={styles.titleWrapper}>
           <Text style={styles.title}>커스텀 태그</Text>
           <Text style={styles.subTitle}>자유롭게 커스텀 태그를 만들어보세요.</Text>
         </View>
 
-        <CategoryCreate 
-          categories={tags} 
+        <CategoryCreate
+          categories={tags}
           onAdd={handleAddTag}
           onDelete={handleDeleteTag}
-          onCategoryChange={handleCategoryChange} 
+          onCategoryChange={handleCategoryChange}
         />
 
-        <CustomButton text={'다음'} style={styles.button} onPress={() => {}} />
+        <CustomButton text={'다음'} style={styles.button} onPress={handleNext} />
       </View>
     </TouchableWithoutFeedback>
   );
@@ -84,29 +97,29 @@ const CustomTag = () => {
 export default CustomTag;
 
 const styles = StyleSheet.create({
-  container: { 
-    flex: 1, 
-    backgroundColor: colors.grayscale[100], 
-    alignItems: 'center', 
-    paddingHorizontal: 20 
+  container: {
+    flex: 1,
+    backgroundColor: colors.grayscale[100],
+    alignItems: 'center',
+    paddingHorizontal: 20,
   },
-  titleWrapper: { 
-    alignItems: 'center', 
-    gap: 8, 
-    marginBottom: 135, 
-    marginTop: 50 
+  titleWrapper: {
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 135,
+    marginTop: 50,
   },
-  title: { 
-    fontFamily: 'Pretendard-Bold', 
-    fontSize: 28 
+  title: {
+    fontFamily: 'Pretendard-Bold',
+    fontSize: 28,
   },
-  subTitle: { 
-    fontFamily: 'Pretendard-Bold', 
-    fontSize: 16, 
-    color: colors.primary[500] 
+  subTitle: {
+    fontFamily: 'Pretendard-Bold',
+    fontSize: 16,
+    color: colors.primary[500],
   },
-  button: { 
-    position: 'absolute', 
-    bottom: 50 
+  button: {
+    position: 'absolute',
+    bottom: 50,
   },
 });

--- a/Peakly-FE/src/screens/onBoardingScreens/Noise.jsx
+++ b/Peakly-FE/src/screens/onBoardingScreens/Noise.jsx
@@ -6,18 +6,33 @@ import ConditionSlider from '../../components/ConditionSlider';
 import Header from './components/Header';
 import CustomButton from '../../components/CustomButton';
 
-const Noise = () => {
+const Noise = ({ navigation, route }) => {
   const [noise, setNoise] = useState(50);
+  const { accumulatedData } = route.params || {};
 
   const getNoiseText = (val) => {
-    if (val <= 0) return '반응이 없는 편이에요.';
+    if (val <= 0) return '상관 없어요.';
     if (val <= 50) return '보통이에요.';
     return '매우 민감해요.';
   };
 
+  const handleNext = () => {
+    let apiValue = 1;
+
+    if (noise <= 0) apiValue = 0;
+    else if (noise <= 50) apiValue = 1;
+    else apiValue = 2;
+    navigation.navigate('Status', {
+      accumulatedData: {
+        ...accumulatedData,
+        noiseSensitivity: apiValue,
+      },
+    });
+  };
+
   return (
     <View style={styles.container}>
-      <Header totalStep={7} currentStep={4} />
+      <Header totalStep={7} currentStep={4} onPress={() => navigation.goBack()} />
       <View style={styles.titleContainer}>
         <Text style={styles.title}>소음 반응도는{'\n'}어떤편인가요?</Text>
       </View>
@@ -31,7 +46,7 @@ const Noise = () => {
           dotCount={3}
         />
       </View>
-      <CustomButton text={'다음'} style={styles.button} />
+      <CustomButton text={'다음'} style={styles.button} onPress={handleNext} />
     </View>
   );
 };

--- a/Peakly-FE/src/screens/onBoardingScreens/OnboardingProfile.jsx
+++ b/Peakly-FE/src/screens/onBoardingScreens/OnboardingProfile.jsx
@@ -6,7 +6,7 @@ import Input from '../../components/Input';
 import { TextInput } from 'react-native-paper';
 import CustomButton from '../../components/CustomButton';
 
-const OnboardingProfile = () => {
+const OnboardingProfile = ({ navigation }) => {
   const [profileImage, setProfileImage] = useState(null);
   const [nickname, setNickname] = useState('');
   const MAX_LENGTH = 10;
@@ -46,7 +46,11 @@ const OnboardingProfile = () => {
         props={inputProps}
         {...inputProps}
       />
-      <CustomButton text={'완료'} style={styles.button} />
+      <CustomButton
+        text={'완료'}
+        style={styles.button}
+        onPress={() => navigation.navigate('ChronoType')}
+      />
     </View>
   );
 };

--- a/Peakly-FE/src/screens/onBoardingScreens/PeakTime.jsx
+++ b/Peakly-FE/src/screens/onBoardingScreens/PeakTime.jsx
@@ -1,4 +1,4 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, Alert } from 'react-native';
 import React, { useState } from 'react';
 import Header from './components/Header';
 import { colors } from '../../styles/colors';
@@ -6,22 +6,55 @@ import OnBording from '../../../assets/img/Onboarding/onboarding1.svg';
 import Button from './components/Button';
 import InteractiveDonutChart from './components/Chart';
 import CustomButton from '../../components/CustomButton';
-const PeakTime = () => {
+const PeakTime = ({ navigation, route }) => {
   const [selected, setSelected] = useState('');
+  const { accumulatedData } = route.params || {};
 
-  const handlePress = (type) => {
-    setSelected(type);
+  const handleChartSelect = (value) => {
+    setSelected(value);
   };
 
+  const handleNext = () => {
+    if (!selected) {
+      Alert.alert('알림', '시간대를 선택해주세요.');
+      return;
+    }
+    let apiValue = '';
+    switch (selected) {
+      case '새벽':
+        apiValue = 'DAWN';
+        break;
+      case '아침':
+        apiValue = 'MORNING';
+        break;
+      case '낮':
+        apiValue = 'AFTERNOON';
+        break;
+      case '저녁':
+        apiValue = 'EVENING';
+        break;
+      case '밤':
+        apiValue = 'NIGHT';
+        break;
+      default:
+        apiValue = 'AFTERNOON';
+    }
+    navigation.navigate('Caffeine', {
+      accumulatedData: {
+        ...accumulatedData,
+        subjectivePeaktime: apiValue,
+      },
+    });
+  };
   return (
     <View style={styles.container}>
-      <Header totalStep={7} currentStep={2} />
+      <Header totalStep={7} currentStep={2} onPress={() => navigation.goBack()} />
       <View style={styles.titleContainer}>
         <Text style={styles.title}>스스로 생각하는 피크타임</Text>
         <Text style={[styles.title, styles.subtitle]}>언제 가장 집중이 잘 되나요?</Text>
       </View>
-      <InteractiveDonutChart />
-      <CustomButton style={styles.button} text={'다음'} />
+      <InteractiveDonutChart onSelect={handleChartSelect} />
+      <CustomButton style={styles.button} text={'다음'} onPress={handleNext} />
     </View>
   );
 };

--- a/Peakly-FE/src/screens/onBoardingScreens/Status.jsx
+++ b/Peakly-FE/src/screens/onBoardingScreens/Status.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { StyleSheet, Text, View, Pressable, useWindowDimensions } from 'react-native';
+import { StyleSheet, Text, View, Pressable, useWindowDimensions, Alert } from 'react-native';
 import { colors } from '../../styles/colors';
 import Student from '../../../assets/img/Onboarding/student.svg';
 import NoJob from '../../../assets/img/Onboarding/noJob.svg';
@@ -8,10 +8,13 @@ import Others from '../../../assets/img/Onboarding/others.svg';
 import CustomButton from '../../components/CustomButton';
 import Header from './components/Header';
 
-const Status = () => {
+const Status = ({ navigation, route }) => {
   const { width } = useWindowDimensions();
   const calWidth = width - 40;
   const [selectedStatus, setSelectedStatus] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const { accumulatedData } = route.params || {};
 
   const statusOptions = [
     { id: 'student', Icon: Student, label: '학생' },
@@ -19,6 +22,30 @@ const Status = () => {
     { id: 'whiteMan', Icon: WhiteMan, label: '직장인' },
     { id: 'others', Icon: Others, label: '기타' },
   ];
+
+  const handleNext = async () => {
+    if (!selectedStatus) {
+      Alert.alert('알림', '현재 상태를 선택해주세요.');
+      return;
+    }
+
+    if (isLoading) return;
+    setIsLoading(true);
+
+    const jobMapping = {
+      student: 'STUDENT',
+      noJob: 'JOB_SEEKER',
+      whiteMan: 'OFFICE_WORKER',
+      others: 'ETC',
+    };
+    const nextAccumulatedData = {
+      ...accumulatedData,
+      job: jobMapping[selectedStatus],
+    };
+    navigation.navigate('CustomTag', {
+      accumulatedData: nextAccumulatedData,
+    });
+  };
 
   const renderButton = (item) => {
     const isSelected = selectedStatus === item.id;
@@ -38,13 +65,13 @@ const Status = () => {
 
   return (
     <View style={styles.container}>
-      <Header totalStep={7} currentStep={5} />
+      <Header totalStep={7} currentStep={5} onPress={() => navigation.goBack()} />
       <Text style={styles.title}>현재는{'\n'}어떤 상태이신가요?</Text>
       <View style={[styles.buttonContainer, { height: calWidth }]}>
         <View style={styles.row}>{statusOptions.slice(0, 2).map(renderButton)}</View>
         <View style={styles.row}>{statusOptions.slice(2, 4).map(renderButton)}</View>
       </View>
-      <CustomButton text={'다음'} style={styles.nextButton} />
+      <CustomButton text={'다음'} style={styles.nextButton} onPress={handleNext} />
     </View>
   );
 };

--- a/Peakly-FE/src/screens/onBoardingScreens/components/Chart.jsx
+++ b/Peakly-FE/src/screens/onBoardingScreens/components/Chart.jsx
@@ -1,19 +1,18 @@
 import React, { useState } from 'react';
 import { View, StyleSheet, Dimensions, Text } from 'react-native';
 import Svg, { Path, G } from 'react-native-svg';
-import { colors } from '../../../styles/colors'; // 경로 확인 필요
+import { colors } from '../../../styles/colors';
 
 const { width } = Dimensions.get('window');
 const chartSize = Math.min(width - 40, 292);
 
-export default function InteractiveDonutChart() {
+export default function InteractiveDonutChart({ onSelect }) {
   const [selectedSegment, setSelectedSegment] = useState(null);
 
-  // 1. 데이터에 텍스트 정보(label, subLabel) 추가
   const segments = [
     {
       id: 1,
-      label: '밤-새벽',
+      label: '새벽',
       subLabel: '22 - 07 시',
       fillPath:
         'M145.599 0.5C225.734 0.500072 290.697 65.4629 290.697 145.599C290.697 146.635 290.684 147.668 290.662 148.699H262.656C262.683 147.669 262.697 146.635 262.697 145.599C262.697 80.9269 210.27 28.5001 145.599 28.5C124.66 28.5 105.006 33.9965 87.998 43.624L73.9961 19.3711C95.1231 7.36101 119.559 0.500024 145.599 0.5Z',
@@ -26,7 +25,7 @@ export default function InteractiveDonutChart() {
     },
     {
       id: 2,
-      label: '오전',
+      label: '아침',
       subLabel: '07 - 12 시',
       fillPath:
         'M290.694 146.042C290.535 199.196 261.796 245.622 219.036 270.765L205.213 246.406C239.507 226.082 262.536 188.759 262.694 146.042H290.694Z',
@@ -37,7 +36,7 @@ export default function InteractiveDonutChart() {
     },
     {
       id: 3,
-      label: '오후',
+      label: '낮',
       subLabel: '12 - 18 시',
       fillPath:
         'M219.175 270.684C198.196 283.05 173.835 290.289 147.812 290.679V262.674C168.754 262.285 188.351 256.402 205.222 246.401L219.175 270.684Z',
@@ -75,11 +74,19 @@ export default function InteractiveDonutChart() {
   ];
 
   const handleSegmentPress = (id) => {
-    // 이미 선택된 걸 누르면 선택 해제(null), 아니면 해당 id 선택
-    setSelectedSegment(selectedSegment === id ? null : id);
+    const nextSelected = selectedSegment === id ? null : id;
+    setSelectedSegment(nextSelected);
+
+    if (onSelect) {
+      if (nextSelected) {
+        const segment = segments.find((s) => s.id === nextSelected);
+        onSelect(segment.label);
+      } else {
+        onSelect('');
+      }
+    }
   };
 
-  // 2. 현재 선택된 세그먼트의 데이터 찾기
   const currentSegment = segments.find((s) => s.id === selectedSegment);
 
   return (
@@ -87,7 +94,6 @@ export default function InteractiveDonutChart() {
       <View style={styles.chartContainer}>
         <Svg width={chartSize} height={chartSize} viewBox="0 0 292 292">
           <G>
-            {/* 세그먼트 Fill */}
             {segments.map((segment) => (
               <Path
                 key={`fill-${segment.id}`}
@@ -96,11 +102,8 @@ export default function InteractiveDonutChart() {
                 onPress={() => handleSegmentPress(segment.id)}
               />
             ))}
-
-            {/* 세그먼트 Stroke */}
             {segments.map((segment) => (
               <G key={`stroke-${segment.id}`}>
-                {/* 기존 Stroke 코드 유지 */}
                 <Path
                   d={segment.strokePath1}
                   fill="none"
@@ -133,13 +136,8 @@ export default function InteractiveDonutChart() {
             ))}
           </G>
         </Svg>
-
-        {/* 3. 텍스트 표시 영역 */}
         <View style={styles.textOverlay} pointerEvents="none">
-          {/* 선택된 세그먼트가 있으면 해당 라벨을, 없으면 '전체' 표시 */}
           <Text style={styles.title}>{currentSegment ? currentSegment.label : '전체'}</Text>
-
-          {/* 선택된 세그먼트가 있으면 해당 시간을, 없으면 '하루 일과' 표시 */}
           <Text style={[styles.title, styles.subTitle]}>
             {currentSegment ? `(${currentSegment.subLabel})` : '하루 일과'}
           </Text>
@@ -171,13 +169,12 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 24,
-    // 폰트가 없다면 fontWeight: 'bold'로 대체 가능
     fontFamily: 'Pretendard-Bold',
     color: '#000',
   },
   subTitle: {
     fontSize: 16,
-    color: colors.primary[500], // colors 객체 확인 필요
+    color: colors.primary[500],
     marginTop: 4,
   },
 });

--- a/Peakly-FE/src/screens/onBoardingScreens/components/Header.jsx
+++ b/Peakly-FE/src/screens/onBoardingScreens/components/Header.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { View, Pressable, StyleSheet, SafeAreaView, Platform, StatusBar } from 'react-native';
 import DesignedArrow from '../../../../assets/img/Onboarding/designedArrow';
 
-const Header = ({ totalStep, currentStep }) => {
+const Header = ({ totalStep, currentStep, onPress }) => {
   return (
     <View style={styles.headerContainer}>
-      <Pressable onPress={() => {}} style={styles.backButton}>
+      <Pressable onPress={onPress} style={styles.backButton}>
         <DesignedArrow />
       </Pressable>
       <View style={styles.progressContainer}>

--- a/Peakly-FE/src/utils/storage.js
+++ b/Peakly-FE/src/utils/storage.js
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const TOKEN_KEY = '@peakly/token';
 const REFRESH_KEY = '@peakly/refresh_token';
+const ONBOARDING_KEY = '@peakly/onboarding.key';
 
 // Access Token 관련 함수
 export const getToken = async () => {
@@ -54,5 +55,33 @@ export const removeRefreshToken = async () => {
     await AsyncStorage.removeItem(REFRESH_KEY);
   } catch (e) {
     console.error('리프레시 토큰 삭제 실패:', e);
+  }
+};
+
+// initial-data 관련 함수
+
+export const getInitialData = async () => {
+  try {
+    const data = await AsyncStorage.getItem(ONBOARDING_KEY);
+    return data ? JSON.parse(data) : null;
+  } catch (e) {
+    console.error('초기 데이터 가져오기 실패: ', e);
+    return null;
+  }
+};
+
+export const setInitialData = async (data) => {
+  try {
+    await AsyncStorage.setItem(ONBOARDING_KEY, JSON.stringify(data));
+  } catch (e) {
+    console.error('초기 데이터 저장 실패: ', e);
+  }
+};
+
+export const removeInitialData = async () => {
+  try {
+    await AsyncStorage.removeItem(ONBOARDING_KEY);
+  } catch (e) {
+    console.error('초기 데이터 삭제 실패: ', e);
   }
 };


### PR DESCRIPTION
## Description

- 초기데이터 (initial-data) api 연동 완료
- 현재는 onboarding, main, auth 스텍을 3단 분기하기 위해 온보딩 데이터를 asycstorage에 저장하여 3단 분기를 하지만 후에 내 정보 조회 api 구현 후 이를 토큰 검증 api 및 3단 분기를 위해 사용할 예정
- issues엔 카테고리 api 연동과 같이 한다고 이슈 생성 하였지만 onboarding category를 성연님이 대신 해주셔서 settings caegory를 대신 할 예정 플로우 먼저 연동을 한 후에 남은 category를 연동해야한다고 생각해 기능순으로 쪼개서 초기데이터 PR 먼저 올림

## Changes
- users.js 파일 생성
- AuthContext, storage.js 수정 / 위와 같은 3단 분기 처리 과정을 위해
- 각 온보딩 스크린 페이지 네이션 및 api 연동